### PR TITLE
don't produce named nodes from semicolons

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -174,7 +174,7 @@ module.exports = grammar({
         commaSeparated($._string),
         $.word_list_qw,
       ),
-      $.semi_colon,
+      ';',
     ),
 
     use_constant_statement: $ => seq(
@@ -186,7 +186,7 @@ module.exports = grammar({
         ),
         field('value', $.hash_ref),
       ),
-      $.semi_colon,
+      ';',
     ),
 
     special_block: $ => seq(
@@ -200,12 +200,12 @@ module.exports = grammar({
     package_statement: $ => seq(
       'package',
       $.package_name,
-      $.semi_colon
+      ';'
     ),
 
     ellipsis_statement: $ => seq(
       '...',
-      optional($.semi_colon),
+      optional(';'),
     ),
 
     use_no_version: $ => seq(
@@ -214,7 +214,7 @@ module.exports = grammar({
         field('no', 'no'),
       ),
       field('version', $.version),
-      $.semi_colon,
+      ';',
     ),
     
     use_no_feature_statement: $ => seq(
@@ -224,7 +224,7 @@ module.exports = grammar({
       ),
       'feature',
       $._experimental_feature,
-      $.semi_colon,
+      ';',
     ),
 
     _experimental_feature: $ => choice(
@@ -271,7 +271,7 @@ module.exports = grammar({
 
     _expression_statement: $ => seq(
       $._expression,
-      $.semi_colon,
+      ';',
     ),
 
     use_no_statement: $ => seq(
@@ -282,7 +282,7 @@ module.exports = grammar({
       choice($.package_name, $.module_name),
       optional($.version),
       optional(choice($._list, $._string)),
-      $.semi_colon,
+      ';',
     ),
 
     use_no_if_statement: $ => seq(
@@ -298,7 +298,7 @@ module.exports = grammar({
       optional($.version),
       optional('=>'),
       optional(choice($._list, $._string)),
-      $.semi_colon,
+      ';',
     ),
 
     // Module->import( LIST );
@@ -307,7 +307,7 @@ module.exports = grammar({
       '->',
       'import',
       $._list,
-      $.semi_colon,
+      ';',
     ),
 
     use_no_subs_statement: $ => seq(
@@ -317,18 +317,18 @@ module.exports = grammar({
       ),
       'subs',
       $._list,
-      $.semi_colon,
+      ';',
     ),
 
     require_statement: $ => seq(
       'require',
       $.package_name,
-      $.semi_colon,
+      ';',
     ),
 
     if_simple_statement: $ => prec.right(seq(
       $._if_simple,
-      $.semi_colon,
+      ';',
     )),
     _if_simple: $ => prec.right(seq(
       'if',
@@ -337,32 +337,32 @@ module.exports = grammar({
     unless_simple_statement: $ => prec.right(seq(
       'unless',
       field('condition', choice($.parenthesized_expression, $._expression)),
-      $.semi_colon,
+      ';',
     )),
     while_simple_statement: $ => prec.right(seq(
       'while',
       field('condition', choice($.parenthesized_expression, $._expression)),
-      $.semi_colon,
+      ';',
     )),
     until_simple_statement: $ => prec.right(seq(
       'until',
       field('condition', choice($.parenthesized_expression, $._expression)),
-      $.semi_colon,
+      ';',
     )),
     for_simple_statement: $ => prec.right(seq(
       'for',
       field('list', with_or_without_brackets($._expression)),
-      $.semi_colon,
+      ';',
     )),
     foreach_simple_statement: $ => prec.right(seq(
       'foreach',
       field('list', with_or_without_brackets($._expression)),
-      $.semi_colon,
+      ';',
     )),
     when_simple_statement: $ => prec.right(seq(
       'when',
       field('condition', choice($.parenthesized_expression, $._expression)),
-      $.semi_colon,
+      ';',
     )),
 
     // TODO: should be a boolean expression and not the current one?
@@ -470,9 +470,9 @@ module.exports = grammar({
     _for_parenthesize: $ => seq(
       '(',
       optional(field('initializer', $._expression)),
-      $.semi_colon,
+      ';',
       optional(field('condition', $._expression)),
-      $.semi_colon,
+      ';',
       optional(field('incrementor', $._expression)),
       ')'
     ),
@@ -507,7 +507,7 @@ module.exports = grammar({
       // or single declaration without brackets
       choice($.multi_var_declaration, $.single_var_declaration, $.type_glob_declaration),
       optional($._initializer),
-      $.semi_colon,
+      ';',
     ),
 
     multi_var_declaration: $ => seq(
@@ -549,7 +549,7 @@ module.exports = grammar({
           optional($.function_prototype),
           optional($.function_attribute),
           optional($.function_signature),
-          $.semi_colon,
+          ';',
         ),
         // and here is the function definition WITHOUT signatures
         seq(
@@ -627,7 +627,7 @@ module.exports = grammar({
 
     _block_statements: $ => choice(
       $._statement,
-      seq($.return_expression, $.semi_colon),
+      seq($.return_expression, ';'),
       $.loop_control_statement,
     ),
 
@@ -636,7 +636,7 @@ module.exports = grammar({
       optional(field('label', $.identifier)),
       choice(
         $._statement_modifiers,
-        $.semi_colon
+        ';'
       ),
     ),
 
@@ -648,11 +648,11 @@ module.exports = grammar({
         '{',
           repeat(choice(
             $._statement,
-            seq($.return_expression, $.semi_colon),
+            seq($.return_expression, ';'),
           )),
         '}'
       )),
-      $.semi_colon,
+      ';',
     )),
 
     parenthesized_expression: $ => seq(
@@ -1348,8 +1348,6 @@ module.exports = grammar({
       seq('\'', /.*pm/, '\''), 
       seq('\"', /.*pm/, '\"'), 
      ),
-
-    semi_colon: $ => ';',
 
     string_single_quoted: $ => prec(PRECEDENCE.STRING, seq(
       "'",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -219,8 +219,8 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -292,8 +292,8 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -359,8 +359,8 @@
           "name": "package_name"
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -375,8 +375,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "semi_colon"
+              "type": "STRING",
+              "value": ";"
             },
             {
               "type": "BLANK"
@@ -418,8 +418,8 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -456,8 +456,8 @@
           "name": "_experimental_feature"
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -586,8 +586,8 @@
           "name": "_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -662,8 +662,8 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -767,8 +767,8 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -796,8 +796,8 @@
           "name": "_list"
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -834,8 +834,8 @@
           "name": "_list"
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -851,8 +851,8 @@
           "name": "package_name"
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -867,8 +867,8 @@
             "name": "_if_simple"
           },
           {
-            "type": "SYMBOL",
-            "name": "semi_colon"
+            "type": "STRING",
+            "value": ";"
           }
         ]
       }
@@ -931,8 +931,8 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "semi_colon"
+            "type": "STRING",
+            "value": ";"
           }
         ]
       }
@@ -965,8 +965,8 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "semi_colon"
+            "type": "STRING",
+            "value": ";"
           }
         ]
       }
@@ -999,8 +999,8 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "semi_colon"
+            "type": "STRING",
+            "value": ";"
           }
         ]
       }
@@ -1050,8 +1050,8 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "semi_colon"
+            "type": "STRING",
+            "value": ";"
           }
         ]
       }
@@ -1101,8 +1101,8 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "semi_colon"
+            "type": "STRING",
+            "value": ";"
           }
         ]
       }
@@ -1135,8 +1135,8 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "semi_colon"
+            "type": "STRING",
+            "value": ";"
           }
         ]
       }
@@ -1680,8 +1680,8 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         },
         {
           "type": "CHOICE",
@@ -1700,8 +1700,8 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         },
         {
           "type": "CHOICE",
@@ -1905,8 +1905,8 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -2099,8 +2099,8 @@
                   ]
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "semi_colon"
+                  "type": "STRING",
+                  "value": ";"
                 }
               ]
             },
@@ -2568,8 +2568,8 @@
               "name": "return_expression"
             },
             {
-              "type": "SYMBOL",
-              "name": "semi_colon"
+              "type": "STRING",
+              "value": ";"
             }
           ]
         },
@@ -2610,8 +2610,8 @@
               "name": "_statement_modifiers"
             },
             {
-              "type": "SYMBOL",
-              "name": "semi_colon"
+              "type": "STRING",
+              "value": ";"
             }
           ]
         }
@@ -2657,8 +2657,8 @@
                             "name": "return_expression"
                           },
                           {
-                            "type": "SYMBOL",
-                            "name": "semi_colon"
+                            "type": "STRING",
+                            "value": ";"
                           }
                         ]
                       }
@@ -2673,8 +2673,8 @@
             }
           },
           {
-            "type": "SYMBOL",
-            "name": "semi_colon"
+            "type": "STRING",
+            "value": ";"
           }
         ]
       }
@@ -6634,7 +6634,7 @@
     },
     "identifier_1": {
       "type": "PATTERN",
-      "value": "[a-zA-Z0-9_$:\\./@%\\^]+"
+      "value": "[a-zA-Z0-9_$:\\.\\/@%\\^]+"
     },
     "identifier_2": {
       "type": "PATTERN",
@@ -6733,10 +6733,6 @@
         }
       ]
     },
-    "semi_colon": {
-      "type": "STRING",
-      "value": ";"
-    },
     "string_single_quoted": {
       "type": "PREC",
       "value": 4,
@@ -6821,7 +6817,7 @@
                       "value": 4,
                       "content": {
                         "type": "PATTERN",
-                        "value": "[^/]+"
+                        "value": "[^\\/]+"
                       }
                     }
                   },
@@ -7330,7 +7326,7 @@
                             "value": 1,
                             "content": {
                               "type": "PATTERN",
-                              "value": "[^/]+"
+                              "value": "[^\\/]+"
                             }
                           }
                         }
@@ -8097,7 +8093,7 @@
             },
             {
               "type": "PATTERN",
-              "value": "[^/\\\\\\[\\n]"
+              "value": "[^\\/\\\\\\[\\n]"
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1650,7 +1650,7 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
@@ -1659,10 +1659,6 @@
         },
         {
           "type": "array_variable",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         },
         {
@@ -3215,10 +3211,6 @@
           "named": true
         },
         {
-          "type": "semi_colon",
-          "named": true
-        },
-        {
           "type": "single_line_statement",
           "named": true
         },
@@ -3441,17 +3433,7 @@
   {
     "type": "ellipsis_statement",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
-    }
+    "fields": {}
   },
   {
     "type": "empty_parenthesized_argument",
@@ -3916,16 +3898,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -4630,16 +4602,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -5120,16 +5082,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -5438,10 +5390,6 @@
         },
         {
           "type": "scope",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         }
       ]
@@ -7879,16 +7827,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -8650,7 +8588,7 @@
     },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "anonymous_function",
@@ -8841,10 +8779,6 @@
           "named": true
         },
         {
-          "type": "semi_colon",
-          "named": true
-        },
-        {
           "type": "single_line_statement",
           "named": true
         },
@@ -9017,10 +8951,6 @@
         },
         {
           "type": "loop_control_keyword",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         },
         {
@@ -9389,7 +9319,7 @@
     },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "anonymous_function",
@@ -9580,10 +9510,6 @@
           "named": true
         },
         {
-          "type": "semi_colon",
-          "named": true
-        },
-        {
           "type": "single_line_statement",
           "named": true
         },
@@ -9738,15 +9664,11 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
           "type": "package_name",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         }
       ]
@@ -10312,15 +10234,11 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
           "type": "package_name",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         }
       ]
@@ -11281,10 +11199,6 @@
           "named": true
         },
         {
-          "type": "semi_colon",
-          "named": true
-        },
-        {
           "type": "single_line_statement",
           "named": true
         },
@@ -11664,10 +11578,6 @@
         },
         {
           "type": "scientific_notation",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         },
         {
@@ -13501,16 +13411,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -14020,16 +13920,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -14324,16 +14214,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -14360,16 +14240,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -14648,10 +14518,6 @@
           "named": true
         },
         {
-          "type": "semi_colon",
-          "named": true
-        },
-        {
           "type": "string_double_quoted",
           "named": true
         },
@@ -14724,10 +14590,6 @@
           "named": true
         },
         {
-          "type": "semi_colon",
-          "named": true
-        },
-        {
           "type": "string_double_quoted",
           "named": true
         },
@@ -14780,7 +14642,7 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
@@ -14789,10 +14651,6 @@
         },
         {
           "type": "array_variable",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         },
         {
@@ -14836,16 +14694,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -14858,10 +14706,6 @@
       "types": [
         {
           "type": "no_require",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         },
         {
@@ -15128,10 +14972,6 @@
         },
         {
           "type": "scope",
-          "named": true
-        },
-        {
-          "type": "semi_colon",
           "named": true
         },
         {
@@ -15412,16 +15252,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -15658,16 +15488,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -15903,6 +15723,10 @@
   },
   {
     "type": "::",
+    "named": false
+  },
+  {
+    "type": ";",
     "named": false
   },
   {
@@ -16251,11 +16075,11 @@
   },
   {
     "type": "prototype",
-    "named": true
+    "named": false
   },
   {
     "type": "prototype",
-    "named": false
+    "named": true
   },
   {
     "type": "push",
@@ -16315,10 +16139,6 @@
   },
   {
     "type": "scientific_notation",
-    "named": true
-  },
-  {
-    "type": "semi_colon",
     "named": true
   },
   {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -19,5 +19,5 @@ my $string = "This is a string with # in it";
 ---
 
 (source_file
-  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (string_double_quoted) (semi_colon))
+  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (string_double_quoted))
 )

--- a/test/corpus/control.txt
+++ b/test/corpus/control.txt
@@ -11,7 +11,7 @@ if (1) {
 (source_file
   (if_statement (parenthesized_expression (integer))
     (block
-      (call_expression (identifier) (argument (string_double_quoted))) (semi_colon)
+      (call_expression (identifier) (argument (string_double_quoted)))
     )
   )
 )
@@ -32,10 +32,10 @@ else {
 (source_file
   (if_statement (parenthesized_expression (integer))
     (block
-      (call_expression (identifier) (argument (string_double_quoted))) (semi_colon)
+      (call_expression (identifier) (argument (string_double_quoted))) 
     )
     (block
-      (call_expression (identifier) (argument (string_double_quoted))) (semi_colon)
+      (call_expression (identifier) (argument (string_double_quoted)))
     )
   )
 )
@@ -54,11 +54,11 @@ while ($i < 10) {
 ---
 
 (source_file
-  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (integer) (semi_colon))
+  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (integer))
   (while_statement (empty_parenthesized_expression (binary_expression (scalar_variable) (integer)))
     (block
-      (call_expression (identifier) (argument (string_double_quoted))) (semi_colon)
-      (unary_expression (scalar_variable)) (semi_colon)
+      (call_expression (identifier) (argument (string_double_quoted)))
+      (unary_expression (scalar_variable))
     )
   )
 )
@@ -79,10 +79,13 @@ MEOW: while ($i < 10) {
 ---
 
 (source_file
-  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (integer) (semi_colon))
+  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (integer) )
   (while_statement (identifier) (empty_parenthesized_expression (binary_expression (scalar_variable) (integer)))
     (block
-      (call_expression (identifier) (argument (string_double_quoted))) (semi_colon) (loop_control_statement (loop_control_keyword) (identifier) (semi_colon)) (unary_expression (scalar_variable)) (semi_colon))
+      (call_expression (identifier) (argument (string_double_quoted))) 
+      (loop_control_statement (loop_control_keyword)
+      (identifier) ) (unary_expression (scalar_variable))
+    )
   )
 )
 
@@ -96,8 +99,8 @@ print "in a loop" for @array;
 ---
 
 (source_file
-  (variable_declaration (scope) (single_var_declaration (array_variable)) (array (integer) (integer) (integer)) (semi_colon))
-  (single_line_statement (call_expression (identifier) (argument (string_double_quoted))) (for_simple_statement (array_variable) (semi_colon)))
+  (variable_declaration (scope) (single_var_declaration (array_variable)) (array (integer) (integer) (integer)) )
+  (single_line_statement (call_expression (identifier) (argument (string_double_quoted))) (for_simple_statement (array_variable) ))
 )
 
 =================================================
@@ -110,7 +113,7 @@ for (my $i=1; $i < 10; $i++) {
 ---
 
 (source_file
-  (for_statement_1 (binary_expression (call_expression (identifier) (argument (scalar_variable))) (integer)) (semi_colon) (binary_expression (scalar_variable) (integer)) (semi_colon) (unary_expression (scalar_variable))
+  (for_statement_1 (binary_expression (call_expression (identifier) (argument (scalar_variable))) (integer))  (binary_expression (scalar_variable) (integer))  (unary_expression (scalar_variable))
     (block)
   )
 )
@@ -126,9 +129,9 @@ for (;;) {
 ---
 
 (source_file
-  (for_statement_1 (semi_colon) (semi_colon)
+  (for_statement_1  
     (block
-      (call_expression (identifier) (argument (string_double_quoted))) (semi_colon)
+      (call_expression (identifier) (argument (string_double_quoted))) 
     )
   )
 )

--- a/test/corpus/experimental.txt
+++ b/test/corpus/experimental.txt
@@ -6,4 +6,4 @@ use feature "switch";
 
 ---
 
-(source_file (use_no_feature_statement (semi_colon)))
+(source_file (use_no_feature_statement ))

--- a/test/corpus/expression.txt
+++ b/test/corpus/expression.txt
@@ -9,7 +9,7 @@ my $a;
 (source_file
   (variable_declaration (scope) (single_var_declaration
     (scalar_variable)
-  ) (semi_colon))
+  ) )
 )
 
 
@@ -23,7 +23,7 @@ my $a = 3;
 
 (source_file
   (variable_declaration (scope) (single_var_declaration
-    (scalar_variable)) (integer) (semi_colon))
+    (scalar_variable)) (integer) )
 )
 
 =================================================
@@ -38,7 +38,7 @@ my ($self, $args) = @_;
   (variable_declaration (scope)
     (multi_var_declaration
       (variable_declarator (scalar_variable)) (variable_declarator (scalar_variable))
-    ) (special_variable) (semi_colon)
+    ) (special_variable) 
   )
 )
 
@@ -53,7 +53,7 @@ my @array;
 (source_file
   (variable_declaration (scope) (single_var_declaration
     (array_variable)
-  ) (semi_colon))
+  ) )
 )
 
 =================================================
@@ -66,7 +66,7 @@ my @array = ('meow', 'woof', 'burp');
 
 (source_file
   (variable_declaration (scope) (single_var_declaration
-    (array_variable)) (array (string_single_quoted) (string_single_quoted) (string_single_quoted)) (semi_colon))
+    (array_variable)) (array (string_single_quoted) (string_single_quoted) (string_single_quoted)) )
 )
 
 =================================================
@@ -87,7 +87,7 @@ my $hash = {
       (string_single_quoted) (hash_arrow_operator) (string_single_quoted)
       (string_double_quoted) (hash_arrow_operator) (string_single_quoted)
       (bareword) (hash_arrow_operator) (string_single_quoted))
-    (semi_colon)))
+    ))
 
 =================================================
 use statement
@@ -98,7 +98,7 @@ use Data::Dumper;
 ---
 
 (source_file
-  (use_no_statement (package_name (identifier) (identifier)) (semi_colon))
+  (use_no_statement (package_name (identifier) (identifier)) )
 )
 
 =================================================
@@ -110,7 +110,7 @@ no strict 'refs';
 ---
 
 (source_file
-  (use_no_statement (package_name (identifier)) (string_single_quoted) (semi_colon))
+  (use_no_statement (package_name (identifier)) (string_single_quoted) )
 )
 
 =================================================
@@ -122,7 +122,7 @@ require Data::Dumper;
 ---
 
 (source_file
-  (require_statement (package_name (identifier) (identifier)) (semi_colon))
+  (require_statement (package_name (identifier) (identifier)) )
 )
 
 =================================================
@@ -146,7 +146,7 @@ $#array;
 ---
 
 (source_file
-  (scalar_variable) (semi_colon)
+  (scalar_variable) 
 )
 
 =================================================
@@ -158,7 +158,7 @@ Double quoted string with escape sequence
 ---
 
 (source_file
-  (string_double_quoted (escape_sequence)) (semi_colon)
+  (string_double_quoted (escape_sequence)) 
 )
 
 =================================================
@@ -175,6 +175,6 @@ my $line = <$fh>;
   (while_statement (empty_parenthesized_expression (standard_input))
     (block)
   )
-  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (standard_input) (semi_colon))
-  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (standard_input_to_variable (scalar_variable)) (semi_colon))
+  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (standard_input) )
+  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (standard_input_to_variable (scalar_variable)) )
 )

--- a/test/corpus/module.txt
+++ b/test/corpus/module.txt
@@ -12,7 +12,7 @@ my $output = BaseModule::YeaThis->hello('first', {
   (variable_declaration (scope) (single_var_declaration (scalar_variable))
   (method_invocation (package_name (identifier) (identifier)) (arrow_operator) (identifier)
     (parenthesized_argument (argument (string_single_quoted) (hash_ref (bareword) (hash_arrow_operator) (string_single_quoted)))))
-  (semi_colon))
+  )
 )
 
 =================================================
@@ -25,5 +25,5 @@ my $output = BaseModule->new();
 
 (source_file
   (variable_declaration (scope) (single_var_declaration (scalar_variable))
-  (method_invocation (identifier) (arrow_operator) (identifier) (empty_parenthesized_argument)) (semi_colon))
+  (method_invocation (identifier) (arrow_operator) (identifier) (empty_parenthesized_argument)) )
 )

--- a/test/corpus/quote-like-operators.txt
+++ b/test/corpus/quote-like-operators.txt
@@ -11,7 +11,7 @@ qq {hello $meow print("dsfsdf) %hash};
     (start_delimiter)
       (interpolation (scalar_variable))
     (end_delimiter))
-  (semi_colon)
+  
 )
 
 =================================================
@@ -23,7 +23,7 @@ qq /im inside another delimiter/;
 ---
 
 (source_file
-  (string_qq_quoted (start_delimiter) (end_delimiter)) (semi_colon)
+  (string_qq_quoted (start_delimiter) (end_delimiter)) 
 )
 
 =================================================
@@ -35,7 +35,7 @@ my $string = q{im a non interpolated string};
 ---
 
 (source_file
-  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (string_q_quoted) (semi_colon))
+  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (string_q_quoted) )
 )
 
 =================================================
@@ -47,7 +47,7 @@ my $string = q{im a non interpolated string};
 ---
 
 (source_file
-  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (string_q_quoted) (semi_colon))
+  (variable_declaration (scope) (single_var_declaration (scalar_variable)) (string_q_quoted) )
 )
 
 =================================================
@@ -64,7 +64,7 @@ my @array = qw /
 
 (source_file
   (variable_declaration
-    (scope) (single_var_declaration (array_variable)) (word_list_qw (identifier_1) (identifier_1) (identifier_1)) (semi_colon)
+    (scope) (single_var_declaration (array_variable)) (word_list_qw (identifier_1) (identifier_1) (identifier_1)) 
   )
 )
 
@@ -79,7 +79,7 @@ $string =~ m/Simple/is;
 (source_file
   (binary_expression
     (scalar_variable) (patter_matcher_m (regex_option))
-  ) (semi_colon)
+  ) 
 )
 
 =================================================
@@ -92,7 +92,7 @@ my $rex = qr/my.STRING/is;
 
 (source_file
   (variable_declaration
-    (scope) (single_var_declaration (scalar_variable)) (regex_pattern_qr (regex_pattern) (regex_option)) (semi_colon)
+    (scope) (single_var_declaration (scalar_variable)) (regex_pattern_qr (regex_pattern) (regex_option)) 
   )
 )
 
@@ -107,7 +107,7 @@ my $subs =~ s/my.STRING/foo/is;
 (source_file
   (variable_declaration 
     (scope) (single_var_declaration (scalar_variable)) (unary_expression
-      (substitution_pattern_s (regex_pattern) (identifier_1) (regex_option_for_substitution))) (semi_colon)
+      (substitution_pattern_s (regex_pattern) (identifier_1) (regex_option_for_substitution))) 
   )
 )
 
@@ -122,6 +122,6 @@ my $subs =~ s/my.STRING/foo/is;
 (source_file
   (variable_declaration 
     (scope) (single_var_declaration (scalar_variable)) (unary_expression
-      (substitution_pattern_s (regex_pattern) (identifier_1) (regex_option_for_substitution))) (semi_colon)
+      (substitution_pattern_s (regex_pattern) (identifier_1) (regex_option_for_substitution))) 
   )
 )

--- a/test/corpus/statement.txt
+++ b/test/corpus/statement.txt
@@ -23,5 +23,5 @@ use constant SOUL_MATE => 'SCORPIO';
 ---
 
 (source_file
-  (use_constant_statement (identifier) (string_single_quoted) (semi_colon))
+  (use_constant_statement (identifier) (string_single_quoted) )
 ) 

--- a/test/corpus/subroutine.txt
+++ b/test/corpus/subroutine.txt
@@ -23,7 +23,7 @@ hello();
 
 (source_file
   (call_expression
-    function_name: (identifier) args: (empty_parenthesized_argument)) (semi_colon)
+    function_name: (identifier) args: (empty_parenthesized_argument)) 
 )
 
 =================================================
@@ -39,7 +39,7 @@ my $result = GetSalesforceTemplateInfo($dbh)->{$args->{ALOHA}}->{'NAMASTE'};
   (call_expression (identifier) (argument
     (arrow_notation
       (arrow_notation (scalar_variable) (arrow_operator) (arrow_notation (scalar_variable) (arrow_operator) (identifier))) (arrow_operator) (string_single_quoted))))
-  (semi_colon))
+  )
 )
 
 =================================================
@@ -52,7 +52,7 @@ print Dumper %{$args};
 
 (source_file
   (call_expression (identifier) (argument
-    (call_expression (identifier) (argument (hash_dereference (scalar_variable)))))) (semi_colon)
+    (call_expression (identifier) (argument (hash_dereference (scalar_variable)))))) 
 )
 
 =================================================


### PR DESCRIPTION
The parse tree should not contain any semi-colons. They don't provide any
syntactic information that isn't already clear from the S-tree that was parsed
