### PR TITLE
Scope in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,13 @@
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.19.4"
-  }
+  },
+  "tree-sitter": [
+      {
+          "scope": "source.perl",
+          "file-types": [
+              "pl"
+          ]
+      }
+  ]
 }


### PR DESCRIPTION
Would be nice to run `tree-sitter parse --scope source.perl /dev/null`.