### PR TITLE
Recognise newer forms of `package` statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -216,7 +216,10 @@ module.exports = grammar({
       'package',
       $.package_name,
       optional(field('version', $.version)),
-      $.semi_colon
+      choice(
+        $.semi_colon,
+        field('body', $.block)
+      )
     ),
 
     ellipsis_statement: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -215,6 +215,7 @@ module.exports = grammar({
     package_statement: $ => seq(
       'package',
       $.package_name,
+      optional(field('version', $.version)),
       $.semi_colon
     ),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,36 @@
 {
   "name": "@ganezdragon/tree-sitter-perl",
-  "version": "0.2.1",
-  "lockfileVersion": 1,
+  "version": "0.3.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@ganezdragon/tree-sitter-perl",
+      "version": "0.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.14.1"
+      },
+      "devDependencies": {
+        "tree-sitter-cli": "^0.19.5"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.5.tgz",
+      "integrity": "sha512-kRzKrUAwpDN9AjA3b0tPBwT1hd8N2oQvvvHup2OEsX6mdsSMLmAvR+NSqK9fe05JrRbVvG8mbteNUQsxlMQohQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "tree-sitter": "cli.js"
+      }
+    }
+  },
   "dependencies": {
     "nan": {
       "version": "2.14.1",
@@ -10,9 +38,9 @@
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "tree-sitter-cli": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.4.tgz",
-      "integrity": "sha512-p2kxjuoQeauXBu5eE+j7c5BMCRXmc17EiAswnnWn3ieUlHXBkA0Z7vRnaCSElDR34MhZnSgqgzuuzQk0cDqCjw==",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.5.tgz",
+      "integrity": "sha512-kRzKrUAwpDN9AjA3b0tPBwT1hd8N2oQvvvHup2OEsX6mdsSMLmAvR+NSqK9fe05JrRbVvG8mbteNUQsxlMQohQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "nan": "^2.14.1"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.4"
+    "tree-sitter-cli": "^0.19.5"
   }
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -375,8 +375,21 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "semi_colon"
+            },
+            {
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "block"
+              }
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -359,6 +359,22 @@
           "name": "package_name"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "version",
+              "content": {
+                "type": "SYMBOL",
+                "name": "version"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "semi_colon"
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -10066,6 +10066,16 @@
     "type": "package_statement",
     "named": true,
     "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      },
       "version": {
         "multiple": false,
         "required": false,

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -10065,7 +10065,18 @@
   {
     "type": "package_statement",
     "named": true,
-    "fields": {},
+    "fields": {
+      "version": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "version",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/test/corpus/package.txt
+++ b/test/corpus/package.txt
@@ -21,3 +21,35 @@ package The::Package v1.23;
 (source_file
   (package_statement (package_name (identifier) (identifier)) (version) (semi_colon))
 )
+
+=================================================
+package block
+=================================================
+
+package The::Package {
+  ...
+}
+
+---
+
+(source_file
+  (package_statement (package_name (identifier) (identifier))
+    (block (ellipsis_statement))
+  )
+)
+
+=================================================
+package block with version
+=================================================
+
+package The::Package v4.56 {
+  ...
+}
+
+---
+
+(source_file
+  (package_statement (package_name (identifier) (identifier)) (version)
+    (block (ellipsis_statement))
+  )
+)

--- a/test/corpus/package.txt
+++ b/test/corpus/package.txt
@@ -1,0 +1,23 @@
+=================================================
+Unit package statement
+=================================================
+
+package The::Package;
+
+---
+
+(source_file
+  (package_statement (package_name (identifier) (identifier)) (semi_colon))
+)
+
+=================================================
+Unit package statement with version
+=================================================
+
+package The::Package v1.23;
+
+---
+
+(source_file
+  (package_statement (package_name (identifier) (identifier)) (version) (semi_colon))
+)


### PR DESCRIPTION
perl 5.12 added

```perl
package NAME VERSION;
```

perl 5.14 added

```perl
package NAME {BLOCK...}
package NAME VERSION {BLOCK...}
```

Not being a Node expert I'm not sure whether the incidental changes to some of the other files included here are valid (e.g. `package-lock.json`). Please let me know what's the correct way to handle these, as I'll have several more additions and edits to hopefully send PRs for.