### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 9.3.5/
 bin/
 build/
+
+# swift bindings
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterPerl",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterPerl", targets: ["TreeSitterPerl"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterPerl",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "examples",
+                    "grammar.js",
+                    "LICENSE",
+                    "package-lock.json",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterPerl/perl.h
+++ b/bindings/swift/TreeSitterPerl/perl.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_PERL_H_
+#define TREE_SITTER_PERL_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_perl();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_PERL_H_


### PR DESCRIPTION
This adds Swift bindings and Swift Package Manager (SPM) support. I maintain the tree-sitter Swift binding here https://github.com/chimeHQ/SwiftTreeSitter

Here are some examples of other PRs:

https://github.com/tree-sitter/tree-sitter-go/pull/79
https://github.com/tree-sitter/tree-sitter-c/pull/105
https://github.com/tree-sitter/tree-sitter-haskell/pull/91

These are manually created. They should not ever impact the parser. Changes that require the use of a cpp scanner, which some parsers need, would require an update. The exclude patterns are pretty safe to get out of sync. They can, in some circumstances, generate warnings for Swift users. But, it's really minor.