### PR TITLE
package name version (from @leonerd; recreated)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -219,7 +219,11 @@ module.exports = grammar({
     package_statement: $ => seq(
       'package',
       $.package_name,
-      $.semi_colon
+      optional(field('version', $.version)),
+      choice(
+        $.semi_colon,
+        field('body', $.block)
+      )
     ),
 
     ellipsis_statement: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -363,8 +363,37 @@
           "name": "package_name"
         },
         {
-          "type": "SYMBOL",
-          "name": "semi_colon"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "version",
+              "content": {
+                "type": "SYMBOL",
+                "name": "version"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "semi_colon"
+            },
+            {
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "block"
+              }
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9350,7 +9350,28 @@
   {
     "type": "package_statement",
     "named": true,
-    "fields": {},
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      },
+      "version": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "version",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,

--- a/test/corpus/package.txt
+++ b/test/corpus/package.txt
@@ -1,0 +1,55 @@
+=================================================
+Unit package statement
+=================================================
+
+package The::Package;
+
+---
+
+(source_file
+  (package_statement (package_name (identifier) (identifier)) (semi_colon))
+)
+
+=================================================
+Unit package statement with version
+=================================================
+
+package The::Package v1.23;
+
+---
+
+(source_file
+  (package_statement (package_name (identifier) (identifier)) (version) (semi_colon))
+)
+
+=================================================
+package block
+=================================================
+
+package The::Package {
+  ...
+}
+
+---
+
+(source_file
+  (package_statement (package_name (identifier) (identifier))
+    (block (ellipsis_statement))
+  )
+)
+
+=================================================
+package block with version
+=================================================
+
+package The::Package v4.56 {
+  ...
+}
+
+---
+
+(source_file
+  (package_statement (package_name (identifier) (identifier)) (version)
+    (block (ellipsis_statement))
+  )
+)


### PR DESCRIPTION
Resurrected from @leonerd's PR https://github.com/ganezdragon/tree-sitter-perl/pull/12 which is a really useful thing to have, and I need it for my WIP [Cursorless](https://www.cursorless.org) Perl support (https://github.com/cursorless-dev/cursorless/pull/1301).

Includes just the manual changes to the grammar and the tests plus the generated files; no package dependencies have been modified for this PR.