### PR TITLE
if/unless fixes; for/foreach cleanup; /g flag for regex

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -267,7 +267,6 @@ module.exports = grammar({
       $.while_simple_statement,
       $.until_simple_statement,
       $.for_simple_statement,
-      $.foreach_simple_statement,
       $.when_simple_statement,
     ),
 
@@ -282,7 +281,6 @@ module.exports = grammar({
       $.until_statement,
       $.for_statement_1,
       $.for_statement_2,
-      $.foreach_statement,
     ),
 
     _expression_statement: $ => seq(
@@ -366,12 +364,7 @@ module.exports = grammar({
       $.semi_colon,
     )),
     for_simple_statement: $ => prec.right(seq(
-      'for',
-      field('list', with_or_without_brackets($._expression)),
-      $.semi_colon,
-    )),
-    foreach_simple_statement: $ => prec.right(seq(
-      'foreach',
+      choice('for', 'foreach'),
       field('list', with_or_without_brackets($._expression)),
       $.semi_colon,
     )),
@@ -454,7 +447,7 @@ module.exports = grammar({
 
     for_statement_2: $ => seq(
       optional(seq(field('label', $.identifier), ':')),
-      'for',
+      choice('for', 'foreach'),
       choice(
         seq(optional($.scope), $.scalar_variable),
         seq('\\', optional($.scope), $.hash_variable), // \my %hash
@@ -484,20 +477,6 @@ module.exports = grammar({
       )
     ),
 
-    foreach_statement: $ => seq(
-      optional(seq(field('label', $.identifier), ':')),
-      'foreach',
-      choice(
-        seq(optional($.scope), $.scalar_variable),
-        seq('\\', optional($.scope), $.hash_variable), // \my %hash
-      ),
-      '(',
-      $._expression,
-      ')',
-      field('body', $.block),
-      optional(field('flow', $.continue)),
-    ),
-    
     _declaration: $ => choice(
       $.function_definition,
       // moving variable_declaration to expressioin

--- a/grammar.js
+++ b/grammar.js
@@ -435,12 +435,12 @@ module.exports = grammar({
       'while',
       field('condition', $.empty_parenthesized_expression),
       field('body', $.block),
-      optional(
-        seq(
-          'continue',
-          field('body', $.block), // normal block for a continue block
-        )
-      ),
+      optional(field('flow', $.continue)),
+    ),
+
+    continue: $ => seq(
+      'continue',
+      field('body', $.block),
     ),
 
     until_statement: $ => seq(
@@ -448,12 +448,7 @@ module.exports = grammar({
       'until',
       field('condition', $.empty_parenthesized_expression),
       field('body', $.block),
-      optional(
-        seq(
-          'continue',
-          field('body', $.block),
-        )
-      ),
+      optional(field('flow', $.continue)),
     ),
 
     // the C - style for loop
@@ -475,12 +470,7 @@ module.exports = grammar({
       $._expression,
       ')',      
       field('body', $.block),
-      optional(
-        seq(
-          'continue',
-          field('body', $.block),
-        )
-      ),
+      optional(field('flow', $.continue)),
     ),
 
     _for_parenthesize: $ => choice(
@@ -512,12 +502,7 @@ module.exports = grammar({
       $._expression,
       ')',
       field('body', $.block),
-      optional(
-        seq(
-          'continue',
-          field('body', $.block),
-        )
-      ),
+      optional(field('flow', $.continue)),
     ),
     
     _declaration: $ => choice(
@@ -646,12 +631,7 @@ module.exports = grammar({
       '{',
       optional(repeat($._block_statements)),
       '}',
-      optional(
-        seq(
-          'continue',
-          field('body', $.block),
-        )
-      ),
+      optional(field('flow', $.continue)),
     ),
 
     _block_statements: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -1689,7 +1689,7 @@ module.exports = grammar({
       ),
     )),
 
-    regex_option: $ => /[msixpodualn]+/,
+    regex_option: $ => /[msixpodualng]+/,
     regex_option_for_substitution: $ => /[msixpodualngcer]+/,
     regex_option_for_transliteration: $ => /[cdsr]+/,
 

--- a/grammar.js
+++ b/grammar.js
@@ -386,35 +386,28 @@ module.exports = grammar({
       'if',
       field('condition', $.parenthesized_expression),
       field('consequence', $.block),
-      optional(repeat(
-        seq(
-          'elsif',
-          field('condition', $.parenthesized_expression),
-          field('alternative_if_consequence', $.block),
-        ),
-      )),
-      optional(seq(
-        'else',
-        field('alternative', $.block),
-      ))
+      repeat(field('alternative', $.elsif_clause)),
+      optional(field('alternative', $.else_clause)),
     )),
 
     unless_statement: $ => prec.left(seq(
       'unless',
       field('condition', $.parenthesized_expression),
       field('consequence', $.block),
-      optional(repeat(
-        seq(
-          'elsif',
-          field('condition', $.parenthesized_expression),
-          field('alternative_if_consequence', $.block),
-        ),
-      )),
-      optional(seq(
-        'else',
-        field('alternative', $.block),
-      ))
+      repeat(field('alternative', $.elsif_clause)),
+      optional(field('alternative', $.else_clause)),
     )),
+
+    elsif_clause: $ => seq(
+      'elsif',
+      field('condition', $.parenthesized_expression),
+      field('alternative_if_consequence', $.block), // 'consequence' to match the Python grammar
+    ),
+
+    else_clause: $ => seq(
+      'else',
+      field('alternative', $.block), // 'body' to match the Python grammar
+    ),
 
     // given_statement: $ => seq(
     //   'given',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -566,10 +566,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "foreach_simple_statement"
-        },
-        {
-          "type": "SYMBOL",
           "name": "when_simple_statement"
         }
       ]
@@ -600,10 +596,6 @@
         {
           "type": "SYMBOL",
           "name": "for_statement_2"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "foreach_statement"
         }
       ]
     },
@@ -1041,59 +1033,17 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
-            "value": "for"
-          },
-          {
-            "type": "FIELD",
-            "name": "list",
-            "content": {
-              "type": "PREC",
-              "value": 31,
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "("
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_expression"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ")"
-                      }
-                    ]
-                  }
-                ]
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "for"
+              },
+              {
+                "type": "STRING",
+                "value": "foreach"
               }
-            }
-          },
-          {
-            "type": "SYMBOL",
-            "name": "semi_colon"
-          }
-        ]
-      }
-    },
-    "foreach_simple_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "foreach"
+            ]
           },
           {
             "type": "FIELD",
@@ -1197,60 +1147,26 @@
             }
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "elsif"
-                    },
-                    {
-                      "type": "FIELD",
-                      "name": "condition",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "parenthesized_expression"
-                      }
-                    },
-                    {
-                      "type": "FIELD",
-                      "name": "alternative_if_consequence",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "block"
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "BLANK"
+            "type": "REPEAT",
+            "content": {
+              "type": "FIELD",
+              "name": "alternative",
+              "content": {
+                "type": "SYMBOL",
+                "name": "elsif_clause"
               }
-            ]
+            }
           },
           {
             "type": "CHOICE",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "else"
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "alternative",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "block"
-                    }
-                  }
-                ]
+                "type": "FIELD",
+                "name": "alternative",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "else_clause"
+                }
               },
               {
                 "type": "BLANK"
@@ -1287,60 +1203,26 @@
             }
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "elsif"
-                    },
-                    {
-                      "type": "FIELD",
-                      "name": "condition",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "parenthesized_expression"
-                      }
-                    },
-                    {
-                      "type": "FIELD",
-                      "name": "alternative_if_consequence",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "block"
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "BLANK"
+            "type": "REPEAT",
+            "content": {
+              "type": "FIELD",
+              "name": "alternative",
+              "content": {
+                "type": "SYMBOL",
+                "name": "elsif_clause"
               }
-            ]
+            }
           },
           {
             "type": "CHOICE",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "else"
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "alternative",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "block"
-                    }
-                  }
-                ]
+                "type": "FIELD",
+                "name": "alternative",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "else_clause"
+                }
               },
               {
                 "type": "BLANK"
@@ -1349,6 +1231,48 @@
           }
         ]
       }
+    },
+    "elsif_clause": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "elsif"
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "parenthesized_expression"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "alternative_if_consequence",
+          "content": {
+            "type": "SYMBOL",
+            "name": "block"
+          }
+        }
+      ]
+    },
+    "else_clause": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "else"
+        },
+        {
+          "type": "FIELD",
+          "name": "alternative",
+          "content": {
+            "type": "SYMBOL",
+            "name": "block"
+          }
+        }
+      ]
     },
     "while_statement": {
       "type": "SEQ",
@@ -1402,26 +1326,34 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "continue"
-                },
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "block"
-                  }
-                }
-              ]
+              "type": "FIELD",
+              "name": "flow",
+              "content": {
+                "type": "SYMBOL",
+                "name": "continue"
+              }
             },
             {
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "continue": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "continue"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "block"
+          }
         }
       ]
     },
@@ -1477,21 +1409,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "continue"
-                },
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "block"
-                  }
-                }
-              ]
+              "type": "FIELD",
+              "name": "flow",
+              "content": {
+                "type": "SYMBOL",
+                "name": "continue"
+              }
             },
             {
               "type": "BLANK"
@@ -1584,8 +1507,17 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "for"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "for"
+            },
+            {
+              "type": "STRING",
+              "value": "foreach"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -1662,21 +1594,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "continue"
-                },
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "block"
-                  }
-                }
-              ]
+              "type": "FIELD",
+              "name": "flow",
+              "content": {
+                "type": "SYMBOL",
+                "name": "continue"
+              }
             },
             {
               "type": "BLANK"
@@ -1751,136 +1674,6 @@
             {
               "type": "STRING",
               "value": ")"
-            }
-          ]
-        }
-      ]
-    },
-    "foreach_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "label",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
-                },
-                {
-                  "type": "STRING",
-                  "value": ":"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "foreach"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "scope"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "scalar_variable"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "\\"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "scope"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "hash_variable"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        },
-        {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "block"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "continue"
-                },
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "block"
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
             }
           ]
         }
@@ -2582,21 +2375,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "continue"
-                },
-                {
-                  "type": "FIELD",
-                  "name": "body",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "block"
-                  }
-                }
-              ]
+              "type": "FIELD",
+              "name": "flow",
+              "content": {
+                "type": "SYMBOL",
+                "name": "continue"
+              }
             },
             {
               "type": "BLANK"
@@ -8277,7 +8061,7 @@
     },
     "regex_option": {
       "type": "PATTERN",
-      "value": "[msixpodualn]+"
+      "value": "[msixpodualng]+"
     },
     "regex_option_for_substitution": {
       "type": "PATTERN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3286,10 +3286,6 @@
           "named": true
         },
         {
-          "type": "foreach_statement",
-          "named": true
-        },
-        {
           "type": "function_definition",
           "named": true
         },
@@ -3655,6 +3651,22 @@
     "fields": {}
   },
   {
+    "type": "continue",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "ellipsis_statement",
     "named": true,
     "fields": {},
@@ -3667,6 +3679,48 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "else_clause",
+    "named": true,
+    "fields": {
+      "alternative": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "elsif_clause",
+    "named": true,
+    "fields": {
+      "alternative_if_consequence": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4939,7 +4993,7 @@
     "named": true,
     "fields": {
       "body": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
@@ -4948,520 +5002,12 @@
           }
         ]
       },
-      "label": {
+      "flow": {
         "multiple": false,
         "required": false,
         "types": [
           {
-            "type": "identifier",
-            "named": true
-          }
-        ]
-      }
-    },
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "array",
-          "named": true
-        },
-        {
-          "type": "array_access_variable",
-          "named": true
-        },
-        {
-          "type": "array_dereference",
-          "named": true
-        },
-        {
-          "type": "array_function",
-          "named": true
-        },
-        {
-          "type": "array_ref",
-          "named": true
-        },
-        {
-          "type": "array_variable",
-          "named": true
-        },
-        {
-          "type": "binary_expression",
-          "named": true
-        },
-        {
-          "type": "bless",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "call_expression_recursive",
-          "named": true
-        },
-        {
-          "type": "command_qx_quoted",
-          "named": true
-        },
-        {
-          "type": "false",
-          "named": true
-        },
-        {
-          "type": "file_handle",
-          "named": true
-        },
-        {
-          "type": "floating_point",
-          "named": true
-        },
-        {
-          "type": "goto_expression",
-          "named": true
-        },
-        {
-          "type": "grep_or_map_function",
-          "named": true
-        },
-        {
-          "type": "hash",
-          "named": true
-        },
-        {
-          "type": "hash_access_variable",
-          "named": true
-        },
-        {
-          "type": "hash_dereference",
-          "named": true
-        },
-        {
-          "type": "hash_ref",
-          "named": true
-        },
-        {
-          "type": "hash_variable",
-          "named": true
-        },
-        {
-          "type": "hexadecimal",
-          "named": true
-        },
-        {
-          "type": "integer",
-          "named": true
-        },
-        {
-          "type": "join_function",
-          "named": true
-        },
-        {
-          "type": "method_invocation",
-          "named": true
-        },
-        {
-          "type": "octal",
-          "named": true
-        },
-        {
-          "type": "package_variable",
-          "named": true
-        },
-        {
-          "type": "patter_matcher_m",
-          "named": true
-        },
-        {
-          "type": "pattern_matcher",
-          "named": true
-        },
-        {
-          "type": "push_function",
-          "named": true
-        },
-        {
-          "type": "regex_pattern_qr",
-          "named": true
-        },
-        {
-          "type": "scalar_reference",
-          "named": true
-        },
-        {
-          "type": "scalar_variable",
-          "named": true
-        },
-        {
-          "type": "scientific_notation",
-          "named": true
-        },
-        {
-          "type": "scope",
-          "named": true
-        },
-        {
-          "type": "sort_function",
-          "named": true
-        },
-        {
-          "type": "special_array_variable",
-          "named": true
-        },
-        {
-          "type": "special_hash_variable",
-          "named": true
-        },
-        {
-          "type": "special_scalar_variable",
-          "named": true
-        },
-        {
-          "type": "standard_input",
-          "named": true
-        },
-        {
-          "type": "standard_input_to_identifier",
-          "named": true
-        },
-        {
-          "type": "standard_input_to_variable",
-          "named": true
-        },
-        {
-          "type": "string_double_quoted",
-          "named": true
-        },
-        {
-          "type": "string_q_quoted",
-          "named": true
-        },
-        {
-          "type": "string_qq_quoted",
-          "named": true
-        },
-        {
-          "type": "string_single_quoted",
-          "named": true
-        },
-        {
-          "type": "substitution_pattern_s",
-          "named": true
-        },
-        {
-          "type": "ternary_expression",
-          "named": true
-        },
-        {
-          "type": "to_reference",
-          "named": true
-        },
-        {
-          "type": "transliteration_tr_or_y",
-          "named": true
-        },
-        {
-          "type": "true",
-          "named": true
-        },
-        {
-          "type": "type_glob",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "unpack_function",
-          "named": true
-        },
-        {
-          "type": "variable_declaration",
-          "named": true
-        },
-        {
-          "type": "word_list_qw",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "foreach_simple_statement",
-    "named": true,
-    "fields": {
-      "list": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "anonymous_function",
-            "named": true
-          },
-          {
-            "type": "array",
-            "named": true
-          },
-          {
-            "type": "array_access_variable",
-            "named": true
-          },
-          {
-            "type": "array_dereference",
-            "named": true
-          },
-          {
-            "type": "array_function",
-            "named": true
-          },
-          {
-            "type": "array_ref",
-            "named": true
-          },
-          {
-            "type": "array_variable",
-            "named": true
-          },
-          {
-            "type": "binary_expression",
-            "named": true
-          },
-          {
-            "type": "bless",
-            "named": true
-          },
-          {
-            "type": "call_expression",
-            "named": true
-          },
-          {
-            "type": "call_expression_recursive",
-            "named": true
-          },
-          {
-            "type": "command_qx_quoted",
-            "named": true
-          },
-          {
-            "type": "false",
-            "named": true
-          },
-          {
-            "type": "file_handle",
-            "named": true
-          },
-          {
-            "type": "floating_point",
-            "named": true
-          },
-          {
-            "type": "goto_expression",
-            "named": true
-          },
-          {
-            "type": "grep_or_map_function",
-            "named": true
-          },
-          {
-            "type": "hash",
-            "named": true
-          },
-          {
-            "type": "hash_access_variable",
-            "named": true
-          },
-          {
-            "type": "hash_dereference",
-            "named": true
-          },
-          {
-            "type": "hash_ref",
-            "named": true
-          },
-          {
-            "type": "hash_variable",
-            "named": true
-          },
-          {
-            "type": "hexadecimal",
-            "named": true
-          },
-          {
-            "type": "integer",
-            "named": true
-          },
-          {
-            "type": "join_function",
-            "named": true
-          },
-          {
-            "type": "local",
-            "named": false
-          },
-          {
-            "type": "method_invocation",
-            "named": true
-          },
-          {
-            "type": "octal",
-            "named": true
-          },
-          {
-            "type": "package_variable",
-            "named": true
-          },
-          {
-            "type": "patter_matcher_m",
-            "named": true
-          },
-          {
-            "type": "pattern_matcher",
-            "named": true
-          },
-          {
-            "type": "push_function",
-            "named": true
-          },
-          {
-            "type": "regex_pattern_qr",
-            "named": true
-          },
-          {
-            "type": "scalar_reference",
-            "named": true
-          },
-          {
-            "type": "scalar_variable",
-            "named": true
-          },
-          {
-            "type": "scientific_notation",
-            "named": true
-          },
-          {
-            "type": "sort_function",
-            "named": true
-          },
-          {
-            "type": "special_array_variable",
-            "named": true
-          },
-          {
-            "type": "special_hash_variable",
-            "named": true
-          },
-          {
-            "type": "special_scalar_variable",
-            "named": true
-          },
-          {
-            "type": "standard_input",
-            "named": true
-          },
-          {
-            "type": "standard_input_to_identifier",
-            "named": true
-          },
-          {
-            "type": "standard_input_to_variable",
-            "named": true
-          },
-          {
-            "type": "string_double_quoted",
-            "named": true
-          },
-          {
-            "type": "string_q_quoted",
-            "named": true
-          },
-          {
-            "type": "string_qq_quoted",
-            "named": true
-          },
-          {
-            "type": "string_single_quoted",
-            "named": true
-          },
-          {
-            "type": "substitution_pattern_s",
-            "named": true
-          },
-          {
-            "type": "ternary_expression",
-            "named": true
-          },
-          {
-            "type": "to_reference",
-            "named": true
-          },
-          {
-            "type": "transliteration_tr_or_y",
-            "named": true
-          },
-          {
-            "type": "true",
-            "named": true
-          },
-          {
-            "type": "type_glob",
-            "named": true
-          },
-          {
-            "type": "unary_expression",
-            "named": true
-          },
-          {
-            "type": "unpack_function",
-            "named": true
-          },
-          {
-            "type": "variable_declaration",
-            "named": true
-          },
-          {
-            "type": "word_list_qw",
-            "named": true
-          }
-        ]
-      }
-    },
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "semi_colon",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "foreach_statement",
-    "named": true,
-    "fields": {
-      "body": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "block",
+            "type": "continue",
             "named": true
           }
         ]
@@ -7407,27 +6953,21 @@
     "named": true,
     "fields": {
       "alternative": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "block",
-            "named": true
-          }
-        ]
-      },
-      "alternative_if_consequence": {
         "multiple": true,
         "required": false,
         "types": [
           {
-            "type": "block",
+            "type": "else_clause",
+            "named": true
+          },
+          {
+            "type": "elsif_clause",
             "named": true
           }
         ]
       },
       "condition": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
@@ -8311,10 +7851,6 @@
           "named": true
         },
         {
-          "type": "foreach_statement",
-          "named": true
-        },
-        {
           "type": "function_definition",
           "named": true
         },
@@ -8595,10 +8131,6 @@
       "types": [
         {
           "type": "for_simple_statement",
-          "named": true
-        },
-        {
-          "type": "foreach_simple_statement",
           "named": true
         },
         {
@@ -9071,10 +8603,6 @@
         },
         {
           "type": "for_statement_2",
-          "named": true
-        },
-        {
-          "type": "foreach_statement",
           "named": true
         },
         {
@@ -10342,10 +9870,6 @@
           "named": true
         },
         {
-          "type": "foreach_simple_statement",
-          "named": true
-        },
-        {
           "type": "goto_expression",
           "named": true
         },
@@ -10888,10 +10412,6 @@
           "named": true
         },
         {
-          "type": "foreach_statement",
-          "named": true
-        },
-        {
           "type": "function_definition",
           "named": true
         },
@@ -11182,12 +10702,12 @@
     "type": "standalone_block",
     "named": true,
     "fields": {
-      "body": {
+      "flow": {
         "multiple": false,
         "required": false,
         "types": [
           {
-            "type": "block",
+            "type": "continue",
             "named": true
           }
         ]
@@ -11281,10 +10801,6 @@
         },
         {
           "type": "for_statement_2",
-          "named": true
-        },
-        {
-          "type": "foreach_statement",
           "named": true
         },
         {
@@ -13355,27 +12871,21 @@
     "named": true,
     "fields": {
       "alternative": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "block",
-            "named": true
-          }
-        ]
-      },
-      "alternative_if_consequence": {
         "multiple": true,
         "required": false,
         "types": [
           {
-            "type": "block",
+            "type": "else_clause",
+            "named": true
+          },
+          {
+            "type": "elsif_clause",
             "named": true
           }
         ]
       },
       "condition": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
@@ -13902,7 +13412,7 @@
     "named": true,
     "fields": {
       "body": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
@@ -13917,6 +13427,16 @@
         "types": [
           {
             "type": "empty_parenthesized_expression",
+            "named": true
+          }
+        ]
+      },
+      "flow": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "continue",
             "named": true
           }
         ]
@@ -15644,7 +15164,7 @@
     "named": true,
     "fields": {
       "body": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
@@ -15659,6 +15179,16 @@
         "types": [
           {
             "type": "empty_parenthesized_expression",
+            "named": true
+          }
+        ]
+      },
+      "flow": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "continue",
             "named": true
           }
         ]
@@ -16892,11 +16422,11 @@
   },
   {
     "type": "prototype",
-    "named": false
+    "named": true
   },
   {
     "type": "prototype",
-    "named": true
+    "named": false
   },
   {
     "type": "push",

--- a/test/corpus/control.txt
+++ b/test/corpus/control.txt
@@ -255,7 +255,7 @@ MEOW: while ($i < 10) {
 )
 
 =================================================
-single line for loop
+postfix for loop
 =================================================
 
 my @array = (1, 3, 4);
@@ -269,7 +269,7 @@ print "in a loop" for @array;
 )
 
 =================================================
-simple for loop TODO: this is failing
+simple for loop (C-style)
 =================================================
 
 for (my $i=1; $i < 10; $i++) {
@@ -284,7 +284,7 @@ for (my $i=1; $i < 10; $i++) {
 )
 
 =================================================
-for ever loop
+infinite for loop (C-style)
 =================================================
 
 for (;;) {
@@ -302,7 +302,22 @@ for (;;) {
 )
 
 =================================================
-foreach loop
+for loop (iterate over array)
+=================================================
+
+for my $single (@array) {
+}
+
+---
+
+(source_file
+  (for_statement_2 (scope) (scalar_variable) (array_variable)
+    (block)
+  )
+)
+
+=================================================
+foreach loop (iterate over array)
 =================================================
 
 foreach my $single (@array) {
@@ -311,7 +326,25 @@ foreach my $single (@array) {
 ---
 
 (source_file
-  (foreach_statement (scope) (scalar_variable) (array_variable)
+  (for_statement_2 (scope) (scalar_variable) (array_variable)
     (block)
+  )
+)
+
+=================================================
+infinite foreach loop
+=================================================
+
+foreach (;;) {
+  print "hello";
+}
+
+---
+
+(source_file
+  (for_statement_1 (semi_colon) (semi_colon)
+    (block
+      (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+    )
   )
 )

--- a/test/corpus/control.txt
+++ b/test/corpus/control.txt
@@ -17,6 +17,32 @@ if (1) {
 )
 
 =================================================
+if elsif block with boolean
+=================================================
+
+if (1) {
+  print "hello";
+}
+elsif (2) {
+  print "elsif";
+}
+
+---
+
+(source_file
+  (if_statement (parenthesized_expression (integer))
+    (block
+      (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+    )
+    (elsif_clause (parenthesized_expression (integer))
+      (block
+        (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+      )
+    )
+  )
+)
+
+=================================================
 if else block with boolean
 =================================================
 
@@ -34,11 +60,153 @@ else {
     (block
       (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
     )
+    (else_clause
+      (block
+        (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+      )
+    )
+  )
+)
+
+=================================================
+if elsif else block with boolean
+=================================================
+
+if (1) {
+  print "hello";
+}
+elsif (2) {
+  print "elsif";
+}
+else {
+  print "else";
+}
+
+---
+
+(source_file
+  (if_statement (parenthesized_expression (integer))
+    (block
+      (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+    )
+    (elsif_clause (parenthesized_expression (integer))
+      (block
+        (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+      )
+    )
+    (else_clause
+      (block
+        (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+      )
+    )
+  )
+)
+
+=================================================
+unless block with boolean
+=================================================
+
+unless (1) {
+  print "hello";
+}
+
+---
+
+(source_file
+  (unless_statement (parenthesized_expression (integer))
     (block
       (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
     )
   )
 )
+
+=================================================
+unless elsif block with boolean
+=================================================
+
+unless (1) {
+  print "hello";
+}
+elsif (2) {
+  print "elsif";
+}
+
+---
+
+(source_file
+  (unless_statement (parenthesized_expression (integer))
+    (block
+      (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+    )
+    (elsif_clause (parenthesized_expression (integer))
+      (block
+        (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+      )
+    )
+  )
+)
+
+=================================================
+unless else block with boolean
+=================================================
+
+unless (1) {
+  print "hello";
+}
+else {
+  print "else";
+}
+
+---
+
+(source_file
+  (unless_statement (parenthesized_expression (integer))
+    (block
+      (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+    )
+    (else_clause
+      (block
+        (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+      )
+    )
+  )
+)
+
+=================================================
+unless elsif else block with boolean
+=================================================
+
+unless (1) {
+  print "hello";
+}
+elsif (2) {
+  print "elsif";
+}
+else {
+  print "else";
+}
+
+---
+
+(source_file
+  (unless_statement (parenthesized_expression (integer))
+    (block
+      (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+    )
+    (elsif_clause (parenthesized_expression (integer))
+      (block
+        (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+      )
+    )
+    (else_clause
+      (block
+        (call_expression (identifier) (arguments (argument (string_double_quoted)))) (semi_colon)
+      )
+    )
+  )
+)
+
+
 
 =================================================
 Simple while statement

--- a/test/corpus/quote-like-operators.txt
+++ b/test/corpus/quote-like-operators.txt
@@ -81,6 +81,20 @@ my @array = qw /
 )
 
 =================================================
+implicit regex matcher - all the flags are allowed, and the regex can have whitespace
+=================================================
+
+$string =~ /a b c/msixpodualng;
+
+---
+
+(source_file
+  (binary_expression
+    (scalar_variable) (pattern_matcher (regex_pattern) (regex_option))
+  ) (semi_colon)
+)
+
+=================================================
 m matcher operator
 =================================================
 
@@ -93,6 +107,21 @@ $string =~ m/Simple/is;
     (scalar_variable) (patter_matcher_m (start_delimiter) (end_delimiter) (regex_option))
   ) (semi_colon)
 )
+
+=================================================
+m matcher operator - global flag is allowed for searches
+=================================================
+
+$string =~ m/abc/g;
+
+---
+
+(source_file
+  (binary_expression
+    (scalar_variable) (patter_matcher_m (start_delimiter) (end_delimiter) (regex_option))
+  ) (semi_colon)
+)
+
 
 =================================================
 m matcher operator - $ at the end shouldn't interpolate


### PR DESCRIPTION
Some fixing, some cleanup, some node tree improvement (combined in a single PR because of the massive generated files), but features can be individually cherry-picked if so desired.

* match-only (not substitution) regexes now allow the `/g` flag.
* `continue` refactored, is now its own statement block and used rather than repeated all over.
* `if` and `unless` refactored a little bit and they now have additional nodes wrapping the `elsif` and `else` conditions just [like in the Python grammar](https://github.com/tree-sitter/tree-sitter-python/blob/62827156d01c74dc1538266344e788da74536b8a/grammar.js), but I kept the field names the same as they were.
* `foreach` in Perl is truly an alias of `for`, so these are now combined in the for nodes.

Tests for all these have been expanded in the individual commits.

(I don't think the large generated files should be committed, but I don't know what if anything would break if these are removed from the repo).