### PR TITLE
chore: tree-sitter is only a dev dependency of the rust bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
+tree-sitter-language = "0.1"
+
+[dev-dependencies]
 tree-sitter = "0.26.3"
-tree-sitter-language = "0.1.6"
 
 [build-dependencies]
 cc = "1.2.51"


### PR DESCRIPTION
Otherwise this causes issues when multiple grammars use different versions of tree-sitter.